### PR TITLE
增加 php built server 的运行方式和让脚本支持多个 md 文件

### DIFF
--- a/development/frontend/php_proxy/README.md
+++ b/development/frontend/php_proxy/README.md
@@ -1,6 +1,21 @@
 # 设置反向代理服务以优化境内访问列表效果
+
 为了优化境内访问列表的效果，可自行设置反向代理服务。但是，如果单纯把整个github一起反代的话，Microsoft和Google有很大的可能认为你正在进行钓鱼而把网站ban掉。
+
 ## 环境要求
-Nginx+PHP
+
+- 部署的环境需要能访问这两个域名
+    - https://raw.githubusercontent.com
+    - https://api.github.com/markdown
+- PHP 7.0+
+- Nginx
+
+以 php built server 的方式运行
+```
+php -S 0.0.0.0:80 index.php
+```
+这种方式不支持 https ，如果需要 https ，要在前面再加一个 TLS 代理。
+建议用于只开发测试。
+
 ## Demo
 https://across.quest/WeNeedHome/

--- a/development/frontend/php_proxy/index.php
+++ b/development/frontend/php_proxy/index.php
@@ -1,39 +1,183 @@
 <?php
-//参考https://haruue.moe/blog/2016/10/06/render-markdown-with-github/
-function curl_raw($url, $content) {
-    $curl = curl_init($url);
-    curl_setopt($curl, CURLOPT_HEADER, false);
-    curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-    curl_setopt($curl, CURLOPT_HTTPHEADER,
-        array("Content-type: application/json",
-              "User-Agent: " . $_SERVER['HTTP_USER_AGENT']));
-    curl_setopt($curl, CURLOPT_POST, true);
-    curl_setopt($curl, CURLOPT_POSTFIELDS, $content);
-    curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false);
 
-    $json_response = curl_exec($curl);
+// 参考 https://haruue.moe/blog/2016/10/06/render-markdown-with-github/
 
-    $status = curl_getinfo($curl, CURLINFO_HTTP_CODE);
+class RepoViewProxy
+{
+    public $githubRawUrl = '';
+    public $githubMarkdownUrl = '';
+    public $repository = '';
+    public $branch = '';
+    public $proxy = '';
+    protected $filepath = '';
+    protected $footer = '';
 
-    curl_close($curl);
+    function __construct(array $config)
+    {
+        $this->githubRawUrl = $config['githubRawUrl'] ?? '';
+        $this->githubMarkdownUrl = $config['githubMarkdownUrl'] ?? '';
+        $this->repository = $config['repository'] ?? '';
+        $this->branch = $config['branch'] ?? '';
+        $this->proxy = $config['proxy'] ?? '';
+        $this->footer = $config['footer'] ?? '';
+    }
 
-    return $json_response;
+    /**
+     * @return resource|false|CurlHandle
+     */
+    protected function getCurl(string $path)
+    {
+        $curl = curl_init($path);
+        curl_setopt($curl, CURLOPT_HEADER, false);
+        curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+        if (!empty($this->proxy)) {
+            $proxy = parse_url($this->proxy);
+            if (is_array($proxy)) {
+                isset($proxy['port']) ? curl_setopt($curl, CURLOPT_PROXYPORT, $proxy['port']) : null;
+                isset($proxy['host']) ? curl_setopt($curl, CURLOPT_PROXY, $proxy['host']) : null;
+                $scheme = isset($proxy['scheme']) ? $proxy['scheme'] : null;
+                switch ($scheme) {
+                    case 'http':
+                        curl_setopt($curl, CURLOPT_PROXYTYPE, CURLPROXY_SOCKS5_HOSTNAME);
+                        break;
+                    case 'https':
+                        curl_setopt($curl, CURLOPT_PROXYTYPE, CURLPROXY_SOCKS5_HOSTNAME);
+                        break;
+                    case 'socks5':
+                        curl_setopt($curl, CURLOPT_PROXYTYPE, CURLPROXY_SOCKS5_HOSTNAME);
+                        break;
+                }
+            }
+        }
+        curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false);
+        return $curl;
+    }
+
+    public function getPath(string $path): string
+    {
+        if (substr($path, 0, 1) != '/') {
+            $path = '/' . $path;
+        }
+        $prefix = '/' . $this->repository . '/' . $this->branch;
+        if (filter_var($path, FILTER_VALIDATE_REGEXP, ['options' => ['regexp' => '/^' . preg_quote($prefix, '/') . '/']])) {
+            $filepath = $this->githubRawUrl . $path;
+        } else {
+            $filepath = $this->githubRawUrl . $prefix . $path;
+        }
+        $this->filepath = $filepath;
+        return $filepath;
+    }
+
+    public function getFile(string $path): string
+    {
+        $curl = $this->getCurl($this->getPath($path));
+        return curl_exec($curl);
+    }
+
+    public function renderMarkdown(string $markdown): string
+    {
+        $content = json_encode([
+            'text' => $markdown,
+            'mode' => 'markdown',
+        ]);
+        $ua = (isset($_SERVER['HTTP_USER_AGENT']) ? $_SERVER['HTTP_USER_AGENT'] : 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.5060.114 Safari/537.36 Edg/103.0.1264.49');
+        $curl = $this->getCurl($this->githubMarkdownUrl);
+        curl_setopt(
+            $curl,
+            CURLOPT_HTTPHEADER,
+            [
+                'Content-type: application/json',
+                'User-Agent: ' . $ua
+            ]
+        );
+        curl_setopt($curl, CURLOPT_POST, true);
+        curl_setopt($curl, CURLOPT_POSTFIELDS, $content);
+        return curl_exec($curl);
+    }
+
+    public function renderTpl(string $html): string
+    {
+        $html = trim($html);
+        $title = basename($this->filepath);
+        preg_match('/<h1>(.*)<\/h1>/s', $html, $match);
+        if (is_array($match) && count($match) > 0) {
+            $titleh1 = trim(strip_tags($match[0]));
+            if (!empty($titleh1)) {
+                $title = $titleh1;
+            }
+        }
+        $title = trim($title);
+
+        $footer = trim($this->footer);
+        if (!empty($footer)) {
+            $footer = '<hr><footer><small>' . $footer . '</small><footer>';
+        }
+
+        $tpl = <<<EOF
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>$title</title>
+</head>
+<article class="markdown-body">
+$html
+</article>
+</body>
+$footer
+</html>
+EOF;
+
+        return $tpl;
+    }
+
+    public function builtServer(string $filepath)
+    {
+        if (filter_var($filepath, FILTER_VALIDATE_REGEXP, ['options' => ['regexp' => '/(.*)\.md$/']])) {
+            $content = $this->renderTpl($this->renderMarkdown($this->getFile($filepath)));
+            header('content-length: ' . strlen($content));
+            header('content-type: text/html; charset=utf-8');
+            echo $content;
+            exit(0);
+        }
+
+        $curl = $this->getCurl($this->getPath($filepath));
+        $content = curl_exec($curl);
+        $curlInfo = curl_getinfo($curl);
+        if (!empty($curlInfo['content_type'])) {
+            header('content-type: ' . $curlInfo['content_type']);
+        } else {
+            header('content-type: application/octet-stream');
+        }
+        header('content-length: ' . strlen($content));
+        // "download_content_length"
+        echo $content;
+    }
 }
 
-copy("https://raw.githubusercontent.com/WeNeedHome/SummaryOfLoanSuspension/main/README.md", "./README.md");
+$config = [
+    'githubRawUrl' => 'https://raw.githubusercontent.com',
+    'githubMarkdownUrl' => 'https://api.github.com/markdown',
+    'repository' => 'WeNeedHome/SummaryOfLoanSuspension',
+    'branch' => 'main',
+    'proxy' => 'socks5://127.0.0.1:6080',
+    'footer' => '
+    以上数据来源：
+    <a target="_blank" href="https://github.com/WeNeedHome/SummaryOfLoanSuspension">https://github.com/WeNeedHome/SummaryOfLoanSuspension</a>
+    <br>
+    本站无法保证上述数据的真实性，如有相关问题请向数据提供方咨询。
+    '
+];
 
-$markdown_filename = "./README.md";
+$filepath = $_SERVER['REQUEST_URI'] ?? '';
+if (empty($filepath) || $filepath == '/' || $filepath == 'README.md') {
+    $filepath = 'README.md';
+}
 
-$markdown_text = file_get_contents($markdown_filename);
+$repoViewProxy = new RepoViewProxy($config);
 
-$render_url = 'https://api.github.com/markdown';
-
-$request_array['text'] = $markdown_text;
-$request_array['mode'] = 'markdown';
-
-$html_article_body = curl_raw($render_url, json_encode($request_array));
-
-echo '<!DOCTYPE html><html><head><meta charset="utf-8"><title>' . $markdown_filename . '</title><link rel="stylesheet" href="/md_github.css" type="text/css" /></head>';
-echo '<article class="markdown-body">';
-echo $html_article_body;
-echo '</article></body><hr><footer>以上数据来源：<a href="https://github.com/WeNeedHome/SummaryOfLoanSuspension">https://github.com/WeNeedHome/SummaryOfLoanSuspension</a><br>本站无法保证上述数据的真实性，如有相关问题请向数据提供方咨询。<footer></html>';
+if (PHP_SAPI == 'cli-server') {
+    $repoViewProxy->builtServer($filepath);
+} else {
+    echo $repoViewProxy->renderTpl($repoViewProxy->renderMarkdown($repoViewProxy->getFile($filepath)));
+}

--- a/development/frontend/php_proxy/proxy.conf
+++ b/development/frontend/php_proxy/proxy.conf
@@ -1,8 +1,26 @@
-#PROXY-START/images
+#PROXY-START
 
-location ^~ /WeNeedHome/images
-{
-    proxy_pass https://raw.githubusercontent.com/WeNeedHome/SummaryOfLoanSuspension/main/images;
+index index.php;
+autoindex off;
+charset UTF-8;
+
+location = / {
+    rewrite / /README.md;
+}
+
+location ~ .*\.(md$) {
+    fastcgi_pass   fastcgi_backend;
+
+    fastcgi_read_timeout 600s;
+    fastcgi_connect_timeout 600s;
+
+    fastcgi_index  index.php;
+    fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
+    include        fastcgi_params;
+}
+
+location ^~ / {
+    proxy_pass https://raw.githubusercontent.com$request_uri;
     proxy_set_header Host raw.githubusercontent.com;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -11,18 +29,17 @@ location ^~ /WeNeedHome/images
     add_header X-Cache $upstream_cache_status;
 
     #Set Nginx Cache
-    
-    
+
     set $static_filemVoya4IL 0;
     if ( $uri ~* "\.(gif|png|jpg|css|js|woff|woff2)$" )
     {
-    	set $static_filemVoya4IL 1;
-    	expires 12h;
-        }
+        set $static_filemVoya4IL 1;
+        expires 12h;
+    }
     if ( $static_filemVoya4IL = 0 )
     {
-    add_header Cache-Control no-cache;
+        add_header Cache-Control no-cache;
     }
 }
 
-#PROXY-END/images
+#PROXY-END


### PR DESCRIPTION
这个 demo
https://across.quest/WeNeedHome/

不能访问除了 README.md 之外的 md 文件
也不能显示除了 ts 或 yml 这类脚本

这个 pr 能使代理更好地显示仓库的内容